### PR TITLE
test: add test for too many arguments in buildCompareRequest

### DIFF
--- a/internal/github/compare_test.go
+++ b/internal/github/compare_test.go
@@ -59,6 +59,13 @@ func TestCompareService_buildCompareRequest(t *testing.T) {
 		},
 	}
 
+	t.Run("Too many arguments", func(t *testing.T) {
+		_, err := service.buildCompareRequest([]string{"branch1", "branch2"})
+		if err == nil {
+			t.Error("Expected error for too many arguments, got nil")
+		}
+	})
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			request, err := service.buildCompareRequest(tt.args)


### PR DESCRIPTION
## Summary
- Adds a test case to verify that `buildCompareRequest` returns an error when given too many arguments

## Test plan
- [x] New test passes with `go test ./internal/github/...`