### PR TITLE
feat: add --url flag to print compare URL to stdout

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"flag"
+	"fmt"
+	"io"
 	"log"
 	"os"
 
@@ -9,22 +12,54 @@ import (
 	"github.com/wassimk/gh-compare/internal/github"
 )
 
-func main() {
+type options struct {
+	printURL bool
+	args     []string
+}
+
+func parseFlags(args []string) options {
+	fs := flag.NewFlagSet("gh-compare", flag.ExitOnError)
+
+	var opts options
+	fs.BoolVar(&opts.printURL, "url", false, "Print the compare URL to standard output")
+	fs.BoolVar(&opts.printURL, "u", false, "Print the compare URL to standard output")
+
+	fs.Parse(args)
+	opts.args = fs.Args()
+
+	return opts
+}
+
+func handleURL(url string, opts options, stdout io.Writer) error {
+	if opts.printURL {
+		fmt.Fprintln(stdout, url)
+		return nil
+	}
+
+	b := browser.New("", os.Stdout, os.Stderr)
+	return b.Browse(url)
+}
+
+func run(opts options, stdout io.Writer) error {
 	repo, err := git.NewRepository(".")
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	compareService := github.NewCompareService(repo)
 
-	args := os.Args[1:]
-	url, err := compareService.GenerateCompareURL(args)
+	url, err := compareService.GenerateCompareURL(opts.args)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
-	browser := browser.New("", os.Stdout, os.Stderr)
-	if err = browser.Browse(url); err != nil {
+	return handleURL(url, opts, stdout)
+}
+
+func main() {
+	opts := parseFlags(os.Args[1:])
+
+	if err := run(opts, os.Stdout); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestParseFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantURL  bool
+		wantArgs []string
+	}{
+		{
+			name:     "no flags",
+			args:     []string{},
+			wantURL:  false,
+			wantArgs: []string{},
+		},
+		{
+			name:     "--url flag",
+			args:     []string{"--url"},
+			wantURL:  true,
+			wantArgs: []string{},
+		},
+		{
+			name:     "-u flag",
+			args:     []string{"-u"},
+			wantURL:  true,
+			wantArgs: []string{},
+		},
+		{
+			name:     "flag with positional arg",
+			args:     []string{"--url", "main..feature"},
+			wantURL:  true,
+			wantArgs: []string{"main..feature"},
+		},
+		{
+			name:     "positional arg only",
+			args:     []string{"main..feature"},
+			wantURL:  false,
+			wantArgs: []string{"main..feature"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := parseFlags(tt.args)
+
+			if opts.printURL != tt.wantURL {
+				t.Errorf("printURL = %v, want %v", opts.printURL, tt.wantURL)
+			}
+
+			if len(opts.args) != len(tt.wantArgs) {
+				t.Fatalf("args length = %d, want %d", len(opts.args), len(tt.wantArgs))
+			}
+
+			for i, arg := range opts.args {
+				if arg != tt.wantArgs[i] {
+					t.Errorf("args[%d] = %q, want %q", i, arg, tt.wantArgs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestHandleURL(t *testing.T) {
+	t.Run("--url prints URL to stdout", func(t *testing.T) {
+		var buf bytes.Buffer
+		opts := options{printURL: true}
+
+		err := handleURL("https://github.com/owner/repo/compare/feature", opts, &buf)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		want := "https://github.com/owner/repo/compare/feature\n"
+		if buf.String() != want {
+			t.Errorf("output = %q, want %q", buf.String(), want)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Refactors `main.go` to use Go's standard `flag` package with an `options` struct, extracting testable `parseFlags`, `handleURL`, and `run` functions
- Adds `-u`/`--url` flag that prints the compare URL to stdout instead of opening the browser, matching `hub compare` behavior
- Adds table-driven tests for flag parsing and URL output

## Test plan

- [ ] `go test ./...` passes
- [ ] `gh compare --url` prints the compare URL to stdout
- [ ] `gh compare -u` prints the compare URL to stdout
- [ ] `gh compare -u main..feature` prints URL with positional arg
- [ ] `gh compare` (no flags) still opens browser as before