### PR TITLE
feat: add --url and --copy flags for compare URL output

### DIFF
--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -1,0 +1,34 @@
+// Package clipboard provides platform-aware clipboard write support.
+package clipboard
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// Write copies text to the system clipboard.
+func Write(text string) error {
+	var cmd *exec.Cmd
+
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("pbcopy")
+	case "linux":
+		if _, err := exec.LookPath("xclip"); err == nil {
+			cmd = exec.Command("xclip", "-selection", "clipboard")
+		} else if _, err := exec.LookPath("xsel"); err == nil {
+			cmd = exec.Command("xsel", "--clipboard", "--input")
+		} else {
+			return fmt.Errorf("no clipboard tool found: install xclip or xsel")
+		}
+	case "windows":
+		cmd = exec.Command("clip")
+	default:
+		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+	}
+
+	cmd.Stdin = strings.NewReader(text)
+	return cmd.Run()
+}

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -1,0 +1,32 @@
+package clipboard
+
+import (
+	"os/exec"
+	"runtime"
+	"testing"
+)
+
+func TestWrite(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		if _, err := exec.LookPath("pbcopy"); err != nil {
+			t.Skip("pbcopy not available")
+		}
+	} else if runtime.GOOS == "linux" {
+		if _, err := exec.LookPath("xclip"); err != nil {
+			if _, err := exec.LookPath("xsel"); err != nil {
+				t.Skip("no clipboard tool available")
+			}
+		}
+	} else if runtime.GOOS == "windows" {
+		if _, err := exec.LookPath("clip"); err != nil {
+			t.Skip("clip not available")
+		}
+	} else {
+		t.Skipf("unsupported platform: %s", runtime.GOOS)
+	}
+
+	err := Write("gh-compare test")
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 )
 
@@ -10,36 +11,70 @@ func TestParseFlags(t *testing.T) {
 		name     string
 		args     []string
 		wantURL  bool
+		wantCopy bool
 		wantArgs []string
 	}{
 		{
 			name:     "no flags",
 			args:     []string{},
 			wantURL:  false,
+			wantCopy: false,
 			wantArgs: []string{},
 		},
 		{
 			name:     "--url flag",
 			args:     []string{"--url"},
 			wantURL:  true,
+			wantCopy: false,
 			wantArgs: []string{},
 		},
 		{
 			name:     "-u flag",
 			args:     []string{"-u"},
 			wantURL:  true,
+			wantCopy: false,
+			wantArgs: []string{},
+		},
+		{
+			name:     "--copy flag",
+			args:     []string{"--copy"},
+			wantURL:  false,
+			wantCopy: true,
+			wantArgs: []string{},
+		},
+		{
+			name:     "-c flag",
+			args:     []string{"-c"},
+			wantURL:  false,
+			wantCopy: true,
+			wantArgs: []string{},
+		},
+		{
+			name:     "both -u and -c",
+			args:     []string{"-u", "-c"},
+			wantURL:  true,
+			wantCopy: true,
 			wantArgs: []string{},
 		},
 		{
 			name:     "flag with positional arg",
 			args:     []string{"--url", "main..feature"},
 			wantURL:  true,
+			wantCopy: false,
+			wantArgs: []string{"main..feature"},
+		},
+		{
+			name:     "copy with positional arg",
+			args:     []string{"-c", "main..feature"},
+			wantURL:  false,
+			wantCopy: true,
 			wantArgs: []string{"main..feature"},
 		},
 		{
 			name:     "positional arg only",
 			args:     []string{"main..feature"},
 			wantURL:  false,
+			wantCopy: false,
 			wantArgs: []string{"main..feature"},
 		},
 	}
@@ -50,6 +85,10 @@ func TestParseFlags(t *testing.T) {
 
 			if opts.printURL != tt.wantURL {
 				t.Errorf("printURL = %v, want %v", opts.printURL, tt.wantURL)
+			}
+
+			if opts.copyToClip != tt.wantCopy {
+				t.Errorf("copyToClip = %v, want %v", opts.copyToClip, tt.wantCopy)
 			}
 
 			if len(opts.args) != len(tt.wantArgs) {
@@ -66,18 +105,86 @@ func TestParseFlags(t *testing.T) {
 }
 
 func TestHandleURL(t *testing.T) {
+	testURL := "https://github.com/owner/repo/compare/feature"
+	noopClip := func(string) error { return nil }
+
 	t.Run("--url prints URL to stdout", func(t *testing.T) {
 		var buf bytes.Buffer
 		opts := options{printURL: true}
 
-		err := handleURL("https://github.com/owner/repo/compare/feature", opts, &buf)
+		err := handleURL(testURL, opts, &buf, noopClip)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		want := "https://github.com/owner/repo/compare/feature\n"
+		want := testURL + "\n"
 		if buf.String() != want {
 			t.Errorf("output = %q, want %q", buf.String(), want)
+		}
+	})
+
+	t.Run("--copy prints URL and calls clipboard func", func(t *testing.T) {
+		var buf bytes.Buffer
+		var clipped string
+		mockClip := func(text string) error {
+			clipped = text
+			return nil
+		}
+		opts := options{copyToClip: true}
+
+		err := handleURL(testURL, opts, &buf, mockClip)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		want := testURL + "\n"
+		if buf.String() != want {
+			t.Errorf("output = %q, want %q", buf.String(), want)
+		}
+
+		if clipped != testURL {
+			t.Errorf("clipboard text = %q, want %q", clipped, testURL)
+		}
+	})
+
+	t.Run("both flags prints URL and copies", func(t *testing.T) {
+		var buf bytes.Buffer
+		var clipped string
+		mockClip := func(text string) error {
+			clipped = text
+			return nil
+		}
+		opts := options{printURL: true, copyToClip: true}
+
+		err := handleURL(testURL, opts, &buf, mockClip)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		want := testURL + "\n"
+		if buf.String() != want {
+			t.Errorf("output = %q, want %q", buf.String(), want)
+		}
+
+		if clipped != testURL {
+			t.Errorf("clipboard text = %q, want %q", clipped, testURL)
+		}
+	})
+
+	t.Run("copy error propagates", func(t *testing.T) {
+		var buf bytes.Buffer
+		failClip := func(string) error {
+			return errors.New("clipboard unavailable")
+		}
+		opts := options{copyToClip: true}
+
+		err := handleURL(testURL, opts, &buf, failClip)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		if !errors.Is(err, errors.Unwrap(err)) && err.Error() != "failed to copy to clipboard: clipboard unavailable" {
+			t.Errorf("error = %q, want wrapped clipboard error", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Refactors `main.go` to use Go's standard `flag` package with an `options` struct, extracting testable `parseFlags`, `handleURL`, and `run` functions
- Adds `-u`/`--url` flag that prints the compare URL to stdout instead of opening the browser
- Adds `-c`/`--copy` flag that prints the URL to stdout and copies it to the system clipboard
- Both flags skip the browser, matching `hub compare` behavior
- Adds `internal/clipboard` package with platform-aware support (pbcopy/xclip/xsel/clip)

## Test plan

- [ ] `go test ./...` passes
- [ ] `gh compare --url` prints the compare URL to stdout
- [ ] `gh compare -u` prints the compare URL to stdout
- [ ] `gh compare --copy` prints URL and copies to clipboard
- [ ] `gh compare -c` prints URL and copies to clipboard
- [ ] `gh compare -u -c` prints URL and copies (both flags)
- [ ] `gh compare` (no flags) still opens browser as before