### PR TITLE
fix: bump release workflow Go version to match go.mod (1.25)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cli/gh-extension-precompile@v2
         with:
-          go_version: "1.24"
+          go_version: "1.25"


### PR DESCRIPTION
## Summary
- The `release` workflow pinned `go_version: "1.24"` for `cli/gh-extension-precompile`, but `go.mod` requires `go 1.25.0`
- With `GOTOOLCHAIN=local` the release job can't auto-download the newer toolchain, so pushing a release tag fails with `go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)`
- Discovered while cutting the v1.0.2 release (dependency bumps only, no source changes)

## Test plan
- [x] N/A — workflow-only change; verified by re-running the release for v1.0.2 after merge