### PR TITLE
fix: restrict GITHUB_TOKEN permissions in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ name: Go Test
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds an explicit `permissions: contents: read` block to `.github/workflows/test.yml`
- Fixes CodeQL code scanning alert #2 (`actions/missing-workflow-permissions`, medium severity): the Go Test workflow had no explicit permissions, so it inherited the repo's default `GITHUB_TOKEN` scope. The job only checks out code, builds, and runs tests, so read-only `contents` access is sufficient.

## Test plan
- [x] Confirm the `Go Test` workflow still runs successfully on this PR
- [ ] Confirm code scanning alert #2 closes automatically after merge